### PR TITLE
Use JSON in xban.db (#26)

### DIFF
--- a/serialize.lua
+++ b/serialize.lua
@@ -27,5 +27,44 @@ local function my_serialize_2(t, level)
 end
 
 function xban.serialize(t)
+	minetest.log("warning", "[xban2] xban.serialize() is deprecated")
 	return "return {\n"..my_serialize_2(t, 1).."\n}"
+end
+
+-- JSON doesn't allow combined string+number keys, this function moves any
+-- number keys into an "entries" table
+function xban.serialize_db(t)
+	local res = {}
+	local entries = {}
+	for k, v in pairs(t) do
+		if type(k) == "number" then
+			entries[k] = v
+		else
+			res[k] = v
+		end
+	end
+	res.entries = entries
+	return minetest.write_json(res, true)
+end
+
+function xban.deserialize_db(s)
+	if s:sub(1, 1) ~= "{" then
+		-- Load legacy databases
+		return minetest.deserialize(s)
+	end
+
+	local res, err = minetest.parse_json(s)
+	if not res then
+		return nil, err
+	end
+
+	-- Remove all "null"s added by empty tables
+	for i, entry in ipairs(res.entries or {}) do
+		entry.names = entry.names or {}
+		entry.record = entry.record or {}
+		res[i] = entry
+	end
+	res.entries = nil
+
+	return res
 end


### PR DESCRIPTION
This should prevent bans database from resetting with a "function has more than 65536 constants" error. Older databases should still be loaded correctly.

Also makes use of minetest.safe_file_write to avoid data corruption.